### PR TITLE
Add support for show-paren-match-expression

### DIFF
--- a/srcery-theme.el
+++ b/srcery-theme.el
@@ -2632,6 +2632,10 @@
      ((,srcery-class (:background ,srcery-magenta :foreground ,srcery-bright-white))
       (,srcery-256-class (:background ,srcery-256-magenta :foreground ,srcery-256-bright-white))))
 
+   `(show-paren-match-expression
+     ((,srcery-class (:inherit highlight))
+      (,srcery-256-class (:inherit highlight))))
+
    `(show-paren-mismatch
      ((,srcery-class (:background ,srcery-red :foreground ,srcery-bright-white))
       (,srcery-256-class (:background ,srcery-256-red :foreground ,srcery-256-bright-white))))


### PR DESCRIPTION
The default properties of `show-paren-match-expression` inherit from `show-paren-match` which in the magenta is a little hard to read. I suggest adding an inherit to it for `highlight`.
<img width="853" height="606" alt="Screenshot 2025-08-28 at 6 21 03 PM" src="https://github.com/user-attachments/assets/e1f6b9ca-cb30-460d-8805-c6485c6e708a" />
<img width="853" height="606" alt="Screenshot 2025-08-28 at 6 21 47 PM" src="https://github.com/user-attachments/assets/ea0ce683-6ca6-4a14-9a60-3245ffc7a052" />
